### PR TITLE
In 1.4 there can be more than one repository for a project

### DIFF
--- a/app/controllers/github_hook_controller.rb
+++ b/app/controllers/github_hook_controller.rb
@@ -5,15 +5,15 @@ class GithubHookController < ApplicationController
   skip_before_filter :verify_authenticity_token, :check_if_login_required
 
   def index
-    if request.post?
-      repository = find_repository
+    repositories = find_repositories
 
-      # Fetch the changes from Github
-      update_repository(repository)
+	repositories.each { |repository|
+        # Fetch the changes from Github
+        update_repository(repository)
 
-      # Fetch the new changesets into Redmine
-      repository.fetch_changesets
-    end
+        # Fetch the new changesets into Redmine
+        repository.fetch_changesets
+	}
 
     render(:text => 'OK')
   end
@@ -71,13 +71,29 @@ class GithubHookController < ApplicationController
     return project
   end
 
-  # Returns the Redmine Repository object we are trying to update
-  def find_repository
+  # Returns the Redmine Repository objects we are trying to update
+  def find_repositories
     project = find_project
-    repository = project.repository
-    raise TypeError, "Project '#{project.to_s}' ('#{project.identifier}') has no repository" if repository.nil?
-    raise TypeError, "Repository for project '#{project.to_s}' ('#{project.identifier}') is not a Git repository" unless repository.is_a?(Repository::Git)
-    return repository
-  end
+    all_repositories = project.repositories
+    payload = JSON.parse(params[:payload])
+    raise TypeError, "Project '#{project.to_s}' ('#{project.identifier}') has no repositories" if all_repositories.empty?
 
+    if params[:repository_id].present?
+        repository = all_repositories.find_by_identifier_param(params[:repository_id])
+        raise TypeError, "Project '#{project.to_s}' ('#{project.identifier}') has no repository with id #{params[:repository_id]}" if repository.nil?
+        raise TypeError, "Repository '#{repository.identifier}' ('#{repository.id}') for project '#{project.to_s}' ('#{project.identifier}') is not a Git repository" unless repository.is_a?(Repository::Git)
+        repositories = Array(repository)
+    elsif params[:update_all]
+        repositories = all_repositories.select { |repository| repository.is_a?(Repository::Git) }
+        raise TypeError, "Project '#{project.to_s}' ('#{project.identifier}') has no Git repositories" if repositories.empty?
+    else
+        repository = project.repository
+        raise TypeError, "Project '#{project.to_s}' ('#{project.identifier}') has no repository" if repository.nil?
+        raise TypeError, "Default Repository for project '#{project.to_s}' ('#{project.identifier}') is not a Git repository" unless repository.is_a?(Repository::Git)
+        repositories = Array(repository)
+    end
+
+
+    return repositories
+  end
 end


### PR DESCRIPTION
We want to handle this in a nice way, thus we enable posibility to
update "default", "specific" and "all" git repos (default might or might
not be a git repo, so we'll have to handle that as well)

To update a specific repo, add parameter "repository_id=NN" to the query
string. to update all repos, add "update_all=yes"
