### PR TITLE
Update README with directory naming.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -16,6 +16,7 @@ That approach works perfectly fine, but is a bit heavy-handed and cumbersome. Th
 1. Installing the plugin
    1. Install the json gem <http://json.rubyforge.org/> on the machine where Redmine is running.
    2. Follow the plugin installation procedure at http://www.redmine.org/wiki/redmine/Plugins.
+      * Make sure that redmine_github_hook is installed in a directory named +redmine_github_hook+
    3. Restart your Redmine.
    4. If you already have a local Git repository set up and working from Redmine go to step 3, otherwise continue at step 2.
 


### PR DESCRIPTION
The default download from github will include the branch name - Redmine expects this to match the actual registered plugin name.
