### PR TITLE
Remove unneeded parsing, make it work with gitlab.

### DIFF
--- a/app/controllers/github_hook_controller.rb
+++ b/app/controllers/github_hook_controller.rb
@@ -74,7 +74,6 @@ class GithubHookController < ApplicationController
   # Returns the Redmine Repository objects we are trying to update
   def find_repositories
     project = find_project
-    payload = JSON.parse(params[:payload])
     all_repositories = project.repositories if project.respond_to? :repositories
     all_repositories ||= Array(project.repository)
     raise TypeError, "Project '#{project.to_s}' ('#{project.identifier}') has no repositories" if all_repositories.empty?


### PR DESCRIPTION
The result of parsing params[:payload] is not used in find_repositories. Deleting it makes redmine_github_hook work with gitlab too.
In master branch this line does not exist.
