### PR TITLE
load path of git command from configuration.yml

### DIFF
--- a/app/controllers/github_hook_controller.rb
+++ b/app/controllers/github_hook_controller.rb
@@ -2,6 +2,7 @@ require 'json'
 
 class GithubHookController < ApplicationController
 
+  GIT_BIN = Redmine::Configuration['scm_git_command'] || "git"
   skip_before_filter :verify_authenticity_token, :check_if_login_required
 
   def index
@@ -52,7 +53,7 @@ class GithubHookController < ApplicationController
   end
 
   def git_command(command, repository)
-    "git --git-dir='#{repository.url}' #{command}"
+    GIT_BIN + " --git-dir='#{repository.url}' #{command}"
   end
 
   # Fetches updates from the remote repository


### PR DESCRIPTION
Hello Jakob,

I am changed to load git cmd path from configuration.yml. Could you merge this?

Thanks, Yuji
