### PR TITLE
Prune repo for deleted branches cleanup

### DIFF
--- a/app/services/github_hook/updater.rb
+++ b/app/services/github_hook/updater.rb
@@ -143,7 +143,7 @@ module GithubHook
     def update_repository(repository)
       command = git_command('fetch origin')
       if exec(command, repository.url)
-        command = git_command("fetch origin \"+refs/heads/*:refs/heads/*\"")
+        command = git_command("fetch --prune origin \"+refs/heads/*:refs/heads/*\"")
         exec(command, repository.url)
       end
     end


### PR DESCRIPTION
Right now if I make a new branch on remote server (github) it would appear on my redmine repo mirror. If then I delete that branch it would still remain there. Git has a `remote prune` command to make such cleanup.

BTW it would be usefull to have a couple of words in README that redmine local repos should be cloned with `--mirror` argument (not `--bare`).