### PR TITLE
add option for non-bare repository

### DIFF
--- a/app/services/github_hook/updater.rb
+++ b/app/services/github_hook/updater.rb
@@ -136,7 +136,7 @@ module GithubHook
     def update_repository(repository)
       command = git_command('fetch origin')
       if exec(command, repository.url)
-        command = git_command("fetch origin \"+refs/heads/*:refs/heads/*\"")
+        command = git_command("fetch origin --update-head-ok \"+refs/heads/*:refs/heads/*\"")
         exec(command, repository.url)
       end
     end


### PR DESCRIPTION
In case of the non-bare repository , the following error occurs .

> fatal: Refusing to fetch into current branch refs/heads/master of non-bare repository