### PR TITLE
Authenticate request with WS repository management API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ That approach works perfectly fine, but is a bit heavy-handed and cumbersome. Th
    `gem "redmine_github_hook"`
 2. `bundle`
 3. Restart your Redmine
+4. Enable **Enable WS for repository management** in **Administration** > **Settings** > **Repositories** and generate an API key
 
 ### 2. Add the repository to Redmine
 
@@ -32,9 +33,9 @@ Adding a Git repository to a project (note, this should work whether you want to
 1. Go to the repository Settings interface on GitHub.
 2. Under "Webhooks & Services" add a new "WebHook". The "Payload URL" needs to be of the format: `[redmine_url]/github_hook` (for example `http://redmine.example.com/github_hook`).
    * By default, GitHub Hook assumes your GitHub repository name is the same as the *project identifier* in your Redmine installation.
-     * If this is not the case, you can specify the actual Redmine project identifier in the Post-Receive URL by using the format `[redmine_url]/github_hook?project_id=[identifier]` (for example `http://redmine.example.com/github_hook?project_id=my_project`).
+     * If this is not the case, you can specify the actual Redmine project identifier in the Post-Receive URL by using the format `[redmine_url]/github_hook?key=[api_key]&project_id=[identifier]` (for example `http://redmine.example.com/github_hook?key=my_api_key&project_id=my_project`).
      * GitHub Hook will then update **all repositories** in the specified project. *Be aware, that this process may take a while if you have many repositories in your project.*
-     * If you want GitHub Hook to **only update the current repository** you can specify it with an additional parameter in the Post-Receive URL by using the format `[redmine_url]/github_hook?project_id=[identifier]&repository_id=[repository]` (for example `http://redmine.example.com/github_hook?project_id=my_project&repository_id=my_repo`).
+     * If you want GitHub Hook to **only update the current repository** you can specify it with an additional parameter in the Post-Receive URL by using the format `[redmine_url]/github_hook?key=[api_key]&project_id=[identifier]&repository_id=[repository]` (for example `http://redmine.example.com/github_hook?key=my_api_key&project_id=my_project&repository_id=my_repo`).
    * In most cases, just having the "push" event trigger the webhook should suffice, but you are free to customize the events as you desire.
    * *Note: Make sure you're adding a Webhook - which is what Redmine Github Hook expects. GitHub has some builtin Redmine integration; that's not what you're looking for.*
 

--- a/app/controllers/github_hook_controller.rb
+++ b/app/controllers/github_hook_controller.rb
@@ -1,6 +1,7 @@
 require "json"
 
 class GithubHookController < ApplicationController
+  before_filter :check_enabled
   skip_before_filter :verify_authenticity_token, :check_if_login_required
 
   def index
@@ -40,5 +41,13 @@ class GithubHookController < ApplicationController
     updater = GithubHook::Updater.new(parse_payload, params)
     updater.logger = logger
     updater.call
+  end
+
+  def check_enabled
+    User.current = nil
+    unless Setting.sys_api_enabled? && params[:key].to_s == Setting.sys_api_key
+      render :text => 'Access denied. Repository management WS is disabled or key is invalid.', :status => 403
+      return false
+    end
   end
 end


### PR DESCRIPTION
This addresses #64 partially, as the API is mandatory but not optional as @fnkr mentioned in the issue.