### PR TITLE
Fix for Redmine version => 4.0.3

### DIFF
--- a/app/controllers/github_hook_controller.rb
+++ b/app/controllers/github_hook_controller.rb
@@ -1,7 +1,7 @@
 require "json"
 
 class GithubHookController < ApplicationController
-  skip_before_filter :verify_authenticity_token, :check_if_login_required
+  skip_before_action :verify_authenticity_token, :check_if_login_required
 
   def index
     message_logger = GithubHook::MessageLogger.new(logger)


### PR DESCRIPTION
Rename `skip_before_filter` to `skip_before_action` because `skip_before_filter` was deprecated in Ruby on Rails 5

---

I'm running redmine on docker and use for it an image `redmine:4.0.4-passenger`. That docker-image uses `ruby 2.6.3p62` and `rails 5.2.3` for redmine.

And I have encountered a problem during using `redmine_github_hook` on this setup - it stops redmine-app with the following error:

```
[ N 2019-06-24 16:39:28.1318 41/Ta age/Cor/SecurityUpdateChecker.h:519 ]: Security update check: no update found (next check in 24 hours)
App 71 output: Error: The application encountered the following error: undefined method `skip_before_filter' for GithubHookController:Class
App 71 output: Did you mean?  skip_before_action (NoMethodError)
```

After a little bit googling I have found that `skip_before_filter` is now reclimed as deprecated [[1]](https://guides.rubyonrails.org/5_0_release_notes.html#action-pack-deprecations) and instead of it `skip_before_action` should be used. I replaced it and now it works as well