### PR TITLE
add migration step to installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ That approach works perfectly fine, but is a bit heavy-handed and cumbersome. Th
 1. Add the gem to your Gemfile.local:
    `gem "redmine_github_hook"`
 2. `bundle`
-3. Restart your Redmine
+3. Run migrations: `bundle exec rake redmine:plugins:migrate RAILS_ENV=production`
+4. Restart your Redmine
 
 ### 2. Add the repository to Redmine
 


### PR DESCRIPTION
After following the installation guide from the README.md I got following error:

    `! Unable to load application: Redmine::PluginNotFound: Plugin not found. The directory for plugin redmine_github_hook should be /home/djbrown/redmine/plugins/redmine_github_hook.`

After I ran migrations the server would startup normally and the plugin works.
`bundle exec rake redmine:plugins:migrate RAILS_ENV=production`