### PR TITLE
prune deleted tags from remote

### DIFF
--- a/app/services/github_hook/updater.rb
+++ b/app/services/github_hook/updater.rb
@@ -159,7 +159,7 @@ module GithubHook
       return nil unless fetch
 
       command = git_command(
-        "fetch --prune origin \"+refs/heads/*:refs/heads/*\""
+        "fetch --prune --prune-tags origin \"+refs/heads/*:refs/heads/*\""
       )
       exec(command, repository.url)
     end

--- a/test/unit/github_hook/updater_test.rb
+++ b/test/unit/github_hook/updater_test.rb
@@ -77,7 +77,7 @@ class GithubHookUpdaterTest < Minitest::Test
     updater
       .expects(:exec)
       .with(
-        "git fetch --prune origin \"+refs/heads/*:refs/heads/*\"",
+        "git fetch --prune --prune-tags origin \"+refs/heads/*:refs/heads/*\"",
         repository.url
       )
     updater.call


### PR DESCRIPTION
for documentation see: https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt---prune-tags
fixes #91